### PR TITLE
feat: add Turkish (tr) translation (initially introduction)

### DIFF
--- a/content/sd/introduction.tr.mdx
+++ b/content/sd/introduction.tr.mdx
@@ -1,0 +1,31 @@
+---
+title: Giriş
+description: Montu Mia'nın sistem tasarımı macerasının başladığı yer
+tags:
+  - Sistem Tasarımına Giriş
+  - Yeni Başlayanlar İçin Sistem Tasarımı
+  - Sistem Tasarımı Öğren
+  - Sistem Tasarımı Temelleri
+  - Yazılım Mimarisi Temelleri
+  - Ölçeklenebilir Sistemler
+---
+
+Montu Mia bir yazılım mühendisi. İyi bir iş, sağlam bir şirket, her şey yolunda. Derken bir gün, hiç beklemediği bir anda aklına milyon dolarlık bir fikir geliyor: **BiralTube** adında bir uygulama; insanların sevimli kedi videoları paylaştığı ve sonunda bütün dünyanın bağımlısı olduğu bir yer. (Bu arada "Biral" kedi demek. Şimdilik öylece kabul ediver.)
+
+Fikir aklına düştüğü an Montu işe koyuluyor. İki ay süren gece mesailerinin ardından uygulama hazır. Yayına alıyor ve... bom, anında bir başarı. Binlerce insan kedilerin kedilik yapmasını izlemek için akın ediyor. Montu bulutların üzerinde; çoktan istifa mektubunu, film kahramanı edasıyla patronunun masasına fırlatmanın hayalini kuruyor.
+
+Ama güzel günler uzun sürmüyor.
+
+Birkaç gün içinde uygulamaya tuhaf küçük hatalar sızmaya başlıyor. Kullanıcılar şikâyet ediyor: yavaş, videolar yüklenmiyor ve birisi "beğen"e dokunduğunda sayı bir türlü... kıpırdamıyor. Bir hata ona, on yüze dönüşüyor ve hepsi birden zavallı Montu'nun üzerine geliyor.
+
+![Beklenti ve Gerçek](/images/sd/introduction/1.png)
+
+Aklı karışıyor. Facebook, Google ve YouTube gibi devler yüz milyonlarca insana hiç zorlanmadan hizmet verirken, onun mütevazı küçük BiralTube'u nasıl oluyor da birkaç bin kullanıcıda tıkanıp nefes nefese kalıyor?
+
+Çaresiz kalan Montu, ofisin bilgesine, herkesin Boltu Mia diye çağırdığı kıdemli mühendise gidiyor. Boltu bütün hazin hikâyeyi dinliyor, bilmiş bir gülümsemeyle şöyle diyor:
+
+**"Bak evlat. Kodu yazmışsın, tamam. Ama hiç gerçekten sistem tasarımı öğrendin mi? Onu atlarsan, böyle bir uygulama her seferinde çöker."**
+
+İşte bu, uyandırıcı bir tokat oldu. Montu kollarını sıvayıp gerçekten çalışmaya başlıyor, bir yandan da yol boyunca BiralTube'u tamir ediyor. Ölçeklendirme, yük dengeleme, bölümleme, CDN'ler; hepsini birer birer, bozulan her şeyi düzelterek bizzat uygulayarak öğreniyor. Ve yavaş yavaş, neredeyse sihir gibi, BiralTube yeniden uçmaya başlıyor.
+
+Sen de bu macerada onunla birlikte yol alacaksın. Her bölümde Montu yeni bir sorunla yüz yüze çarpışacak ve biz birlikte akıllıca sistem tasarımı çözümünü bulacağız.

--- a/content/sd/meta.tr.json
+++ b/content/sd/meta.tr.json
@@ -1,0 +1,16 @@
+{
+  "title": "Montu Mia'nın Sistem Tasarımı",
+  "root": true,
+  "pages": [
+    "introduction",
+    "what-is-system-design",
+    "scaling",
+    "load-balancer",
+    "networking",
+    "cdn",
+    "caching",
+    "data-partitioning",
+    "replication",
+    "hook"
+  ]
+}

--- a/public/flags/tr.svg
+++ b/public/flags/tr.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800"><rect width="1200" height="800" fill="#E30A17"/><circle cx="425" cy="400" r="200" fill="#fff"/><circle cx="475" cy="400" r="160" fill="#E30A17"/><path fill="#fff" d="m583.34 400 256.97 83.48-158.83-218.62v270.28l158.83-218.62z"/></svg>

--- a/src/dictionaries/tr.json
+++ b/src/dictionaries/tr.json
@@ -1,0 +1,30 @@
+{
+  "home": {
+    "imageAlt": "Montu Mia'nın Sistem Tasarımı",
+    "heroTitle": "Montu Mia'nın Sistem Tasarımı Macerası",
+    "heroSubtitle1": "Montu Mia binlerce BiralTube kullanıcısıyla başa çıkmakta zorlanıyor!",
+    "heroSubtitle2": "Kod yazmayı öğrendin, ama uygulama sistem tasarımı olmadan ayakta kalabilir mi?",
+    "ctaStart": "Okumaya başla"
+  },
+  "a11y": {
+    "changeLanguage": "Dili değiştir"
+  },
+  "sidebar": {
+    "aboutAuthor": "Yazar hakkında"
+  },
+  "subscribe": {
+    "trigger": "Abone ol",
+    "title": "Güncellemelere abone ol",
+    "description": "Yeni bir bölüm yayınlandığında sana e-posta göndereceğiz.",
+    "emailLabel": "E-posta",
+    "placeholder": "ad@ornek.com",
+    "submit": "Abone ol",
+    "success": "Teşekkürler! Başarıyla abone oldun."
+  },
+  "errors": {
+    "invalidEmail": "Lütfen geçerli bir e-posta adresi girin",
+    "rateLimit": "Çok fazla deneme. Lütfen {minutes} dakika sonra tekrar deneyin.",
+    "serverConfig": "Sunucu yapılandırma hatası",
+    "generic": "Bir şeyler ters gitti. Lütfen tekrar deneyin."
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,7 @@
 export const BASE_URL = "https://www.montumia.com";
 
 export const DEFAULT_LOCALE = "bn" as const;
-export const LOCALES = ["bn", "en"] as const;
+export const LOCALES = ["bn", "en", "tr"] as const;
 export type Locale = (typeof LOCALES)[number];
 
 // Per-locale metadata. To add a language, add an entry here (see TRANSLATING.md).
@@ -28,6 +28,13 @@ export const LOCALE_META: Record<
     label: "English",
     flag: "/flags/us.svg",
     hreflang: "en-US",
+  },
+  tr: {
+    ogLocale: "tr_TR",
+    siteName: "Montu Mia'nın Sistem Tasarımı",
+    label: "Türkçe",
+    flag: "/flags/tr.svg",
+    hreflang: "tr-TR",
   },
 };
 

--- a/src/lib/dictionaries.ts
+++ b/src/lib/dictionaries.ts
@@ -1,5 +1,6 @@
 import bn from "@/dictionaries/bn.json";
 import en from "@/dictionaries/en.json";
+import tr from "@/dictionaries/tr.json";
 import { type Locale, normalizeLocale } from "@/lib/constants";
 
 // Widen JSON literal types to `string`, keeping bn.json's key structure as the contract.
@@ -8,7 +9,7 @@ type Widen<T> = T extends string ? string : { [K in keyof T]: Widen<T[K]> };
 export type Dictionary = Widen<typeof bn>;
 
 // Typing this as Record<Locale, Dictionary> makes a missing en.json key a compile error.
-const dictionaries: Record<Locale, Dictionary> = { bn, en };
+const dictionaries: Record<Locale, Dictionary> = { bn, en, tr };
 
 export function getDictionary(lang: string): Dictionary {
   return dictionaries[normalizeLocale(lang)];

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -23,6 +23,9 @@ export const { provider } = defineI18nUI(i18n, {
     en: {
       displayName: "English",
     },
+    tr: {
+      displayName: "Türkçe",
+    },
   },
 });
 


### PR DESCRIPTION
Adds Turkish (`tr`) as a new locale, built on top of the i18n work in #18.

**Wiring**
- `tr` added to `LOCALES` + `LOCALE_META` in `src/lib/constants.ts`
- Registered in `src/lib/dictionaries.ts` and the language switcher in `src/lib/layout.shared.tsx`
- `src/dictionaries/tr.json` — full Turkish UI strings
- `public/flags/tr.svg` — flag asset

**Content**
- `content/sd/introduction.tr.mdx` — first chapter translated
- `content/sd/meta.tr.json` — translated nav title
- Remaining chapters fall back to Bengali for now; I'll translate them incrementally.

`bun run types:check` passes. Verified `/tr`, `/tr/sd/introduction`, and Bengali fallback for untranslated pages all return 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Turkish language support throughout the platform, including:
    * Turkish user interface translations and localization
    * Turkish System Design documentation and introduction content
    * Turkish locale configuration for proper metadata and URL handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->